### PR TITLE
Add Windows GUI launcher and packaging tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,26 @@ pip install -e .[dev]
 pytest
 ```
 
-The current code is platform agnostic and focuses on core coordination logic. Windows-specific integrations (Win32 capture, SendInput) are abstracted behind service interfaces and can be implemented in future iterations with native bindings.
+The core coordination logic remains platform agnostic. Windows-specific integrations (Win32 capture, SendInput) are exposed via the new GUI layer described below.
+
+## Launching the Windows GUI
+
+The desktop application depends on Qt via PySide6 and currently targets Windows. Install the GUI extras and invoke the launcher:
+
+```bash
+pip install -e .[gui]
+scu-gui
+```
+
+Alternatively, you can run the module directly with `python -m scu.gui.main`. The application persists the most recent configuration using the existing `ConfigRepository` and allows you to start, pause, resume, and stop capture sessions from a single window.
+
+## Building a standalone executable
+
+To distribute the tool as a single `.exe`, install the build extras and run the packaging helper (PyInstaller must be executed on Windows for a functional binary):
+
+```bash
+pip install -e .[build]
+scu-build-exe --dist dist --name scu-capture
+```
+
+The command produces an executable in the chosen `dist` directory. Use `--onedir` to emit a folder-based distribution or `--no-clean` for quicker iterative builds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,16 @@ dependencies = []
 dev = [
     "pytest",
 ]
+gui = [
+    "PySide6>=6.6.0",
+]
+build = [
+    "pyinstaller>=6.0.0",
+]
+
+[project.scripts]
+scu-gui = "scu.gui.main:main"
+scu-build-exe = "scu.tools.build_exe:main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/scu/gui/__init__.py
+++ b/src/scu/gui/__init__.py
@@ -1,0 +1,5 @@
+"""Graphical user interface for the SCU automation toolkit."""
+
+from .main import main
+
+__all__ = ["main"]

--- a/src/scu/gui/__main__.py
+++ b/src/scu/gui/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/src/scu/gui/main.py
+++ b/src/scu/gui/main.py
@@ -1,0 +1,397 @@
+"""Qt-based desktop application entry point for SCU."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import QMetaObject, QObject, Qt, QThread, Signal, Slot
+from PySide6.QtWidgets import (
+    QApplication,
+    QComboBox,
+    QDoubleSpinBox,
+    QFileDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QListWidget,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+    QProgressBar,
+)
+
+from ..config import AppConfig, CaptureMode, ConfigRepository, Direction, WaitMode
+from ..events import ErrorEvent, ProgressEvent, StateChangeEvent, WarningEvent
+from ..output import FilesystemOutputWriter
+from ..pipeline import Pipeline
+from ..platform import Win32CaptureService, Win32InputService, Win32WaitService
+from ..session import SessionController, SessionState
+
+
+class SessionWorker(QObject):
+    """Background worker that drives the session controller."""
+
+    progress = Signal(int, object, object)
+    warning = Signal(str)
+    error = Signal(str)
+    state_changed = Signal(str)
+    finished = Signal()
+
+    def __init__(self, config: AppConfig, session_name: Optional[str] = None) -> None:
+        super().__init__()
+        pipeline = Pipeline(
+            capture_service=Win32CaptureService(),
+            input_service=Win32InputService(),
+            wait_service=Win32WaitService(),
+            output_writer=FilesystemOutputWriter(),
+        )
+        self._controller = SessionController(
+            config=config,
+            pipeline=pipeline,
+            event_callback=self._handle_event,
+        )
+        self._session_name = session_name
+        self._stop_requested = False
+
+    @property
+    def controller(self) -> SessionController:
+        return self._controller
+
+    def _handle_event(self, event: ProgressEvent | WarningEvent | ErrorEvent | StateChangeEvent) -> None:
+        if isinstance(event, ProgressEvent):
+            image_path = str(event.image_path) if event.image_path else ""
+            self.progress.emit(event.step_index, event.total_steps, image_path)
+        elif isinstance(event, WarningEvent):
+            self.warning.emit(event.message)
+        elif isinstance(event, ErrorEvent):
+            self.error.emit(event.message)
+        elif isinstance(event, StateChangeEvent):
+            self.state_changed.emit(event.state)
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            self._controller.start(session_name=self._session_name)
+            while True:
+                state = self._controller.state
+                if state == SessionState.RUNNING:
+                    if self._stop_requested:
+                        self._controller.request_stop()
+                        self._stop_requested = False
+                    self._controller.step()
+                elif state == SessionState.PAUSED:
+                    QThread.msleep(100)
+                else:
+                    break
+        except Exception as exc:  # noqa: BLE001 - propagate domain failures
+            self.error.emit(str(exc))
+        finally:
+            self.finished.emit()
+
+    @Slot()
+    def pause(self) -> None:
+        self._controller.pause()
+
+    @Slot()
+    def resume(self) -> None:
+        self._controller.resume()
+
+    @Slot()
+    def stop(self) -> None:
+        self._stop_requested = True
+        if self._controller.state == SessionState.PAUSED:
+            self._controller.stop()
+
+
+class MainWindow(QMainWindow):
+    """Primary application window."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("SCU Capture Utility")
+        self.resize(720, 520)
+
+        self._config_repo = ConfigRepository()
+        self._current_config = self._config_repo.load_recent()
+        self._worker_thread: Optional[QThread] = None
+        self._worker: Optional[SessionWorker] = None
+
+        self._build_ui()
+        self._apply_config(self._current_config)
+
+    def _build_ui(self) -> None:
+        central = QWidget(self)
+        layout = QVBoxLayout(central)
+
+        form_layout = QFormLayout()
+        layout.addLayout(form_layout)
+
+        self.monitor_spin = QSpinBox()
+        self.monitor_spin.setMinimum(1)
+        self.monitor_spin.setMaximum(16)
+        form_layout.addRow("Monitor", self.monitor_spin)
+
+        self.capture_mode_combo = QComboBox()
+        self.capture_mode_combo.addItem("Active window", CaptureMode.ACTIVE_WINDOW)
+        self.capture_mode_combo.addItem("Full monitor", CaptureMode.FULL_MONITOR)
+        form_layout.addRow("Capture mode", self.capture_mode_combo)
+
+        self.direction_combo = QComboBox()
+        self.direction_combo.addItem("Right (→)", Direction.RIGHT)
+        self.direction_combo.addItem("Left (←)", Direction.LEFT)
+        form_layout.addRow("Direction", self.direction_combo)
+
+        self.count_spin = QSpinBox()
+        self.count_spin.setRange(1, 10_000)
+        form_layout.addRow("Capture count", self.count_spin)
+
+        self.delay_spin = QDoubleSpinBox()
+        self.delay_spin.setRange(0.0, 60.0)
+        self.delay_spin.setDecimals(2)
+        self.delay_spin.setSingleStep(0.1)
+        form_layout.addRow("Delay (s)", self.delay_spin)
+
+        self.wait_mode_combo = QComboBox()
+        self.wait_mode_combo.addItem("Fixed delay", WaitMode.FIXED)
+        self.wait_mode_combo.addItem("Wait for change", WaitMode.CHANGE_DETECTION)
+        self.wait_mode_combo.currentIndexChanged.connect(self._on_wait_mode_changed)
+        form_layout.addRow("Wait mode", self.wait_mode_combo)
+
+        self.wait_timeout_spin = QDoubleSpinBox()
+        self.wait_timeout_spin.setRange(0.1, 600.0)
+        self.wait_timeout_spin.setDecimals(2)
+        self.wait_timeout_spin.setSingleStep(0.5)
+        form_layout.addRow("Wait timeout (s)", self.wait_timeout_spin)
+
+        output_layout = QHBoxLayout()
+        self.output_edit = QLineEdit()
+        output_layout.addWidget(self.output_edit)
+        browse_button = QPushButton("Browse…")
+        browse_button.clicked.connect(self._on_browse_output)
+        output_layout.addWidget(browse_button)
+        form_layout.addRow("Output directory", output_layout)
+
+        control_layout = QHBoxLayout()
+        self.start_button = QPushButton("Start")
+        self.start_button.clicked.connect(self.start_session)
+        control_layout.addWidget(self.start_button)
+
+        self.pause_button = QPushButton("Pause")
+        self.pause_button.clicked.connect(self.pause_session)
+        self.pause_button.setEnabled(False)
+        control_layout.addWidget(self.pause_button)
+
+        self.resume_button = QPushButton("Resume")
+        self.resume_button.clicked.connect(self.resume_session)
+        self.resume_button.setEnabled(False)
+        control_layout.addWidget(self.resume_button)
+
+        self.stop_button = QPushButton("Stop")
+        self.stop_button.clicked.connect(self.stop_session)
+        self.stop_button.setEnabled(False)
+        control_layout.addWidget(self.stop_button)
+
+        layout.addLayout(control_layout)
+
+        self.status_label = QLabel("Idle")
+        layout.addWidget(self.status_label)
+
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setMinimum(0)
+        self.progress_bar.setValue(0)
+        layout.addWidget(self.progress_bar)
+
+        self.log_list = QListWidget()
+        layout.addWidget(self.log_list, stretch=1)
+
+        self.setCentralWidget(central)
+
+    def _apply_config(self, config: AppConfig) -> None:
+        self.monitor_spin.setValue(config.monitor)
+        self.capture_mode_combo.setCurrentIndex(0 if config.capture_mode is CaptureMode.ACTIVE_WINDOW else 1)
+        self.direction_combo.setCurrentIndex(0 if config.direction is Direction.RIGHT else 1)
+        self.count_spin.setValue(config.count)
+        self.delay_spin.setValue(config.delay)
+        self.wait_mode_combo.setCurrentIndex(0 if config.wait_mode is WaitMode.FIXED else 1)
+        if config.wait_timeout is not None:
+            self.wait_timeout_spin.setValue(config.wait_timeout)
+        self.wait_timeout_spin.setEnabled(config.wait_mode is WaitMode.CHANGE_DETECTION)
+        self.output_edit.setText(str(config.output_dir))
+
+    def _build_config(self) -> AppConfig:
+        capture_mode = self.capture_mode_combo.currentData()
+        if not isinstance(capture_mode, CaptureMode):
+            capture_mode = CaptureMode.ACTIVE_WINDOW
+        direction = self.direction_combo.currentData()
+        if not isinstance(direction, Direction):
+            direction = Direction.RIGHT
+        wait_mode = self.wait_mode_combo.currentData()
+        if not isinstance(wait_mode, WaitMode):
+            wait_mode = WaitMode.FIXED
+        wait_timeout: Optional[float]
+        if wait_mode is WaitMode.CHANGE_DETECTION:
+            wait_timeout = float(self.wait_timeout_spin.value())
+        else:
+            wait_timeout = None
+        output_dir = Path(self.output_edit.text()).expanduser()
+        return replace(
+            self._current_config,
+            monitor=int(self.monitor_spin.value()),
+            capture_mode=capture_mode,
+            direction=direction,
+            count=int(self.count_spin.value()),
+            delay=float(self.delay_spin.value()),
+            wait_mode=wait_mode,
+            wait_timeout=wait_timeout,
+            output_dir=output_dir,
+        )
+
+    def _ensure_worker(self) -> bool:
+        return self._worker_thread is None
+
+    def start_session(self) -> None:
+        if sys.platform != "win32":
+            QMessageBox.critical(self, "Unsupported platform", "The GUI is only available on Windows.")
+            return
+        if not self._ensure_worker():
+            return
+        try:
+            config = self._build_config()
+        except ValueError as exc:
+            QMessageBox.warning(self, "Invalid configuration", str(exc))
+            return
+        self._current_config = config
+        self._config_repo.save_recent(config)
+
+        self.log_list.clear()
+        self.progress_bar.setMaximum(1)
+        self.progress_bar.setValue(0)
+        self.status_label.setText("Starting…")
+
+        try:
+            worker = SessionWorker(config)
+        except RuntimeError as exc:
+            QMessageBox.critical(self, "Unavailable", str(exc))
+            self._reset_controls()
+            return
+        thread = QThread(self)
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.finished.connect(thread.quit)
+        worker.finished.connect(worker.deleteLater)
+        thread.finished.connect(thread.deleteLater)
+        worker.progress.connect(self._on_progress)
+        worker.warning.connect(self._on_warning)
+        worker.error.connect(self._on_error)
+        worker.state_changed.connect(self._on_state_change)
+        thread.finished.connect(self._on_worker_finished)
+
+        self._worker = worker
+        self._worker_thread = thread
+        thread.start()
+
+        self.start_button.setEnabled(False)
+        self.pause_button.setEnabled(True)
+        self.resume_button.setEnabled(False)
+        self.stop_button.setEnabled(True)
+
+    def pause_session(self) -> None:
+        if self._worker is None:
+            return
+        QMetaObject.invokeMethod(self._worker, "pause", Qt.QueuedConnection)
+        self.pause_button.setEnabled(False)
+        self.resume_button.setEnabled(True)
+
+    def resume_session(self) -> None:
+        if self._worker is None:
+            return
+        QMetaObject.invokeMethod(self._worker, "resume", Qt.QueuedConnection)
+        self.pause_button.setEnabled(True)
+        self.resume_button.setEnabled(False)
+
+    def stop_session(self) -> None:
+        if self._worker is None:
+            return
+        QMetaObject.invokeMethod(self._worker, "stop", Qt.QueuedConnection)
+
+    def _on_browse_output(self) -> None:
+        directory = QFileDialog.getExistingDirectory(self, "Select output directory", self.output_edit.text())
+        if directory:
+            self.output_edit.setText(directory)
+
+    def _on_wait_mode_changed(self, index: int) -> None:
+        mode = self.wait_mode_combo.itemData(index)
+        self.wait_timeout_spin.setEnabled(mode is WaitMode.CHANGE_DETECTION)
+
+    def _on_progress(self, step_index: int, total_steps: object, image_path: object) -> None:
+        if isinstance(total_steps, int) and total_steps > 0:
+            self.progress_bar.setMaximum(total_steps)
+            self.progress_bar.setValue(step_index)
+        else:
+            self.progress_bar.setMaximum(0)
+        if isinstance(image_path, str) and image_path:
+            self.log_list.addItem(f"Saved: {image_path}")
+        else:
+            self.log_list.addItem(f"Completed step {step_index}")
+        self.log_list.scrollToBottom()
+
+    def _on_warning(self, message: str) -> None:
+        self.log_list.addItem(f"Warning: {message}")
+        self.log_list.scrollToBottom()
+
+    def _on_error(self, message: str) -> None:
+        self.log_list.addItem(f"Error: {message}")
+        self.log_list.scrollToBottom()
+        QMessageBox.critical(self, "Session error", message)
+        self._reset_controls()
+
+    def _on_state_change(self, state: str) -> None:
+        self.status_label.setText(state.capitalize())
+        if state == SessionState.RUNNING.value:
+            self.pause_button.setEnabled(True)
+            self.resume_button.setEnabled(False)
+        elif state == SessionState.PAUSED.value:
+            self.pause_button.setEnabled(False)
+            self.resume_button.setEnabled(True)
+        elif state in {SessionState.STOPPED.value, SessionState.ERROR.value, SessionState.IDLE.value}:
+            self._reset_controls(state.capitalize())
+
+    def _on_worker_finished(self) -> None:
+        self._worker = None
+        self._worker_thread = None
+        self._reset_controls()
+
+    def _reset_controls(self, status: Optional[str] = None) -> None:
+        self.start_button.setEnabled(True)
+        self.pause_button.setEnabled(False)
+        self.resume_button.setEnabled(False)
+        self.stop_button.setEnabled(False)
+        if self.progress_bar.maximum() == 0:
+            self.progress_bar.setMaximum(1)
+        self.status_label.setText(status or "Idle")
+
+    def closeEvent(self, event) -> None:  # type: ignore[override]
+        if self._worker is not None and self._worker_thread is not None:
+            QMetaObject.invokeMethod(self._worker, "stop", Qt.QueuedConnection)
+            self._worker_thread.quit()
+            self._worker_thread.wait(2000)
+        super().closeEvent(event)
+
+
+def main() -> None:
+    """Launch the GUI application."""
+
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    sys.exit(app.exec())
+
+
+__all__ = ["main", "MainWindow", "SessionWorker"]

--- a/src/scu/output.py
+++ b/src/scu/output.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional
 
 from .config import AppConfig, ImageFormat
+from .interfaces import OutputWriter
 
 
 class SessionPathManager:
@@ -35,12 +36,26 @@ class SessionPathManager:
 
     def write_capture(self, index: int, image_format: ImageFormat, image_bytes: bytes, jpeg_quality: int = 90) -> Path:
         path = self.capture_path(index, image_format)
-        if image_format is ImageFormat.JPG:
-            path.write_bytes(image_bytes)
-        else:
-            path.write_bytes(image_bytes)
+        path.write_bytes(image_bytes)
         return path
 
     @staticmethod
     def hash_bytes(data: bytes) -> str:
         return hashlib.sha1(data).hexdigest()
+
+
+class FilesystemOutputWriter(OutputWriter):
+    """Persist captures to disk within the prepared session directory."""
+
+    def write_capture(
+        self,
+        session_dir: Path,
+        index: int,
+        image_format: ImageFormat,
+        image_bytes: bytes,
+        jpeg_quality: int,
+    ) -> Path:
+        session_dir.mkdir(parents=True, exist_ok=True)
+        path = session_dir / f"page_{index:04d}{image_format.extension}"
+        path.write_bytes(image_bytes)
+        return path

--- a/src/scu/platform/__init__.py
+++ b/src/scu/platform/__init__.py
@@ -1,0 +1,15 @@
+"""Platform-specific service implementations."""
+
+from .windows import (
+    Rect,
+    Win32CaptureService,
+    Win32InputService,
+    Win32WaitService,
+)
+
+__all__ = [
+    "Rect",
+    "Win32CaptureService",
+    "Win32InputService",
+    "Win32WaitService",
+]

--- a/src/scu/platform/windows.py
+++ b/src/scu/platform/windows.py
@@ -1,0 +1,349 @@
+"""Windows-specific service implementations."""
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import io
+import sys
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional, Protocol, Sequence
+
+from ..config import CaptureMode, Direction
+from ..interfaces import CaptureRequest, CaptureResult, CaptureService, InputService, WaitService
+
+try:  # pragma: no cover - optional dependency used only on Windows at runtime
+    from PIL import Image  # type: ignore
+except Exception:  # pragma: no cover - pillow is optional
+    Image = None  # type: ignore
+
+
+@dataclass(frozen=True)
+class Rect:
+    """Simple rectangle utility."""
+
+    left: int
+    top: int
+    right: int
+    bottom: int
+
+    @property
+    def width(self) -> int:
+        return max(0, self.right - self.left)
+
+    @property
+    def height(self) -> int:
+        return max(0, self.bottom - self.top)
+
+    @property
+    def area(self) -> int:
+        return self.width * self.height
+
+    def intersect(self, other: "Rect") -> "Rect":
+        return Rect(
+            left=max(self.left, other.left),
+            top=max(self.top, other.top),
+            right=min(self.right, other.right),
+            bottom=min(self.bottom, other.bottom),
+        )
+
+    def clamp_within(self, bounds: "Rect") -> "Rect":
+        return Rect(
+            left=max(self.left, bounds.left),
+            top=max(self.top, bounds.top),
+            right=min(self.right, bounds.right),
+            bottom=min(self.bottom, bounds.bottom),
+        )
+
+    def overlap_ratio(self, other: "Rect") -> float:
+        if self.area == 0:
+            return 0.0
+        intersection = self.intersect(other)
+        return intersection.area / self.area
+
+
+class Win32API(Protocol):
+    """Protocol for Win32 API access used by the services."""
+
+    def list_monitors(self) -> Sequence[Rect]:
+        ...
+
+    def get_foreground_window_rect(self) -> Rect | None:
+        ...
+
+    def capture_rect(self, rect: Rect) -> bytes:
+        ...
+
+    def send_key(self, vk_code: int) -> None:
+        ...
+
+
+class Win32CaptureService(CaptureService):
+    """Capture service backed by Win32 APIs."""
+
+    def __init__(self, api: Optional[Win32API] = None) -> None:
+        if api is None and sys.platform != "win32":  # pragma: no cover - requires Windows
+            raise RuntimeError("Win32CaptureService can only be used on Windows")
+        self.api = api or RealWin32API()  # type: ignore[arg-type]
+
+    def capture(self, request: CaptureRequest) -> CaptureResult:
+        monitors = list(self.api.list_monitors())
+        if request.monitor < 1 or request.monitor > len(monitors):
+            raise ValueError(f"Monitor {request.monitor} is not available")
+        monitor_rect = monitors[request.monitor - 1]
+
+        if request.capture_mode is CaptureMode.FULL_MONITOR:
+            target_rect = monitor_rect
+        else:
+            window_rect = self.api.get_foreground_window_rect()
+            if window_rect is None:
+                raise RuntimeError("No active window detected")
+            if window_rect.overlap_ratio(monitor_rect) < request.min_overlap:
+                raise RuntimeError("Active window does not meet the minimum overlap requirement")
+            target_rect = window_rect.clamp_within(monitor_rect)
+
+        if target_rect.area == 0:
+            raise RuntimeError("Target capture area is empty")
+
+        image_bytes = self.api.capture_rect(target_rect)
+        hash_value = hashlib.sha1(image_bytes).hexdigest() if image_bytes else None
+        return CaptureResult(
+            image_bytes=image_bytes,
+            width=target_rect.width,
+            height=target_rect.height,
+            hash_value=hash_value,
+        )
+
+
+class Win32InputService(InputService):
+    """Input service that sends arrow keys using Win32 SendInput."""
+
+    VK_LEFT = 0x25
+    VK_RIGHT = 0x27
+
+    def __init__(self, api: Optional[Win32API] = None) -> None:
+        if api is None and sys.platform != "win32":  # pragma: no cover - requires Windows
+            raise RuntimeError("Win32InputService can only be used on Windows")
+        self.api = api or RealWin32API()  # type: ignore[arg-type]
+
+    def send_direction(self, direction: Direction) -> None:
+        vk_code = self.VK_LEFT if direction is Direction.LEFT else self.VK_RIGHT
+        self.api.send_key(vk_code)
+
+
+class Win32WaitService(WaitService):
+    """Wait service supporting both fixed delay and change detection polling."""
+
+    def __init__(
+        self,
+        change_detector: Optional[Callable[[], str | None]] = None,
+        poll_interval: float = 0.1,
+        sleep_fn: Callable[[float], None] | None = None,
+        monotonic_fn: Callable[[], float] | None = None,
+    ) -> None:
+        self._change_detector = change_detector
+        self._poll_interval = max(0.01, poll_interval)
+        self._sleep = sleep_fn or time.sleep
+        self._monotonic = monotonic_fn or time.monotonic
+
+    def wait_fixed(self, delay_seconds: float) -> None:
+        if delay_seconds > 0:
+            self._sleep(delay_seconds)
+
+    def wait_for_change(self, previous_hash: str | None, timeout_seconds: float) -> bool:
+        if timeout_seconds <= 0:
+            return True
+        if self._change_detector is None:
+            self._sleep(timeout_seconds)
+            return True
+        deadline = self._monotonic() + timeout_seconds
+        while self._monotonic() < deadline:
+            current_hash = self._change_detector()
+            if current_hash is None:
+                self._sleep(self._poll_interval)
+                continue
+            if previous_hash is None or current_hash != previous_hash:
+                return True
+            remaining = max(0.0, deadline - self._monotonic())
+            self._sleep(min(self._poll_interval, remaining))
+        return False
+
+
+class Win32Error(RuntimeError):
+    """Raised when a Win32 API call fails."""
+
+
+if sys.platform == "win32":  # pragma: no cover - real API only exercised on Windows
+    from ctypes import wintypes
+
+    SRCCOPY = 0x00CC0020
+    DIB_RGB_COLORS = 0
+    BI_RGB = 0
+    INPUT_KEYBOARD = 1
+    KEYEVENTF_KEYUP = 0x0002
+
+    class _RECT(ctypes.Structure):
+        _fields_ = [
+            ("left", wintypes.LONG),
+            ("top", wintypes.LONG),
+            ("right", wintypes.LONG),
+            ("bottom", wintypes.LONG),
+        ]
+
+    class BITMAPINFOHEADER(ctypes.Structure):
+        _fields_ = [
+            ("biSize", wintypes.DWORD),
+            ("biWidth", wintypes.LONG),
+            ("biHeight", wintypes.LONG),
+            ("biPlanes", wintypes.WORD),
+            ("biBitCount", wintypes.WORD),
+            ("biCompression", wintypes.DWORD),
+            ("biSizeImage", wintypes.DWORD),
+            ("biXPelsPerMeter", wintypes.LONG),
+            ("biYPelsPerMeter", wintypes.LONG),
+            ("biClrUsed", wintypes.DWORD),
+            ("biClrImportant", wintypes.DWORD),
+        ]
+
+    class BITMAPINFO(ctypes.Structure):
+        _fields_ = [
+            ("bmiHeader", BITMAPINFOHEADER),
+            ("bmiColors", wintypes.DWORD * 1),
+        ]
+
+    class KEYBDINPUT(ctypes.Structure):
+        _fields_ = [
+            ("wVk", wintypes.WORD),
+            ("wScan", wintypes.WORD),
+            ("dwFlags", wintypes.DWORD),
+            ("time", wintypes.DWORD),
+            ("dwExtraInfo", wintypes.ULONG_PTR),
+        ]
+
+    class _INPUTUNION(ctypes.Union):
+        _fields_ = [("ki", KEYBDINPUT)]
+
+    class INPUT(ctypes.Structure):
+        _fields_ = [("type", wintypes.DWORD), ("union", _INPUTUNION)]
+
+    MonitorEnumProc = ctypes.WINFUNCTYPE(
+        wintypes.BOOL,
+        wintypes.HMONITOR,
+        wintypes.HDC,
+        ctypes.POINTER(_RECT),
+        wintypes.LPARAM,
+    )
+
+    class RealWin32API:
+        def __init__(self) -> None:
+            self.user32 = ctypes.windll.user32
+            self.gdi32 = ctypes.windll.gdi32
+            self.user32.SetProcessDPIAware()
+
+        def list_monitors(self) -> Sequence[Rect]:
+            monitors: list[Rect] = []
+
+            def _callback(hmonitor: wintypes.HMONITOR, hdc: wintypes.HDC, rect_ptr: ctypes.POINTER(_RECT), lparam: wintypes.LPARAM) -> wintypes.BOOL:
+                rect = rect_ptr.contents
+                monitors.append(Rect(rect.left, rect.top, rect.right, rect.bottom))
+                return True
+
+            if not self.user32.EnumDisplayMonitors(None, None, MonitorEnumProc(_callback), 0):
+                raise Win32Error("EnumDisplayMonitors failed")
+            if not monitors:
+                raise Win32Error("No monitors detected")
+            return monitors
+
+        def get_foreground_window_rect(self) -> Rect | None:
+            hwnd = self.user32.GetForegroundWindow()
+            if not hwnd:
+                return None
+            rect = _RECT()
+            if not self.user32.GetWindowRect(hwnd, ctypes.byref(rect)):
+                raise Win32Error("GetWindowRect failed")
+            return Rect(rect.left, rect.top, rect.right, rect.bottom)
+
+        def capture_rect(self, rect: Rect) -> bytes:
+            width, height = rect.width, rect.height
+            if width == 0 or height == 0:
+                return b""
+
+            hdc_screen = self.user32.GetDC(0)
+            if not hdc_screen:
+                raise Win32Error("GetDC failed")
+            hdc_mem = self.gdi32.CreateCompatibleDC(hdc_screen)
+            if not hdc_mem:
+                self.user32.ReleaseDC(0, hdc_screen)
+                raise Win32Error("CreateCompatibleDC failed")
+            bitmap = self.gdi32.CreateCompatibleBitmap(hdc_screen, width, height)
+            if not bitmap:
+                self.gdi32.DeleteDC(hdc_mem)
+                self.user32.ReleaseDC(0, hdc_screen)
+                raise Win32Error("CreateCompatibleBitmap failed")
+            try:
+                if not self.gdi32.SelectObject(hdc_mem, bitmap):
+                    raise Win32Error("SelectObject failed")
+                if not self.gdi32.BitBlt(hdc_mem, 0, 0, width, height, hdc_screen, rect.left, rect.top, SRCCOPY):
+                    raise Win32Error("BitBlt failed")
+
+                bmi = BITMAPINFO()
+                ctypes.memset(ctypes.byref(bmi), 0, ctypes.sizeof(bmi))
+                bmi.bmiHeader.biSize = ctypes.sizeof(BITMAPINFOHEADER)
+                bmi.bmiHeader.biWidth = width
+                bmi.bmiHeader.biHeight = -height  # top-down bitmap
+                bmi.bmiHeader.biPlanes = 1
+                bmi.bmiHeader.biBitCount = 32
+                bmi.bmiHeader.biCompression = BI_RGB
+
+                buffer_size = width * height * 4
+                buffer = (ctypes.c_ubyte * buffer_size)()
+                if not self.gdi32.GetDIBits(
+                    hdc_mem,
+                    bitmap,
+                    0,
+                    height,
+                    ctypes.byref(buffer),
+                    ctypes.byref(bmi),
+                    DIB_RGB_COLORS,
+                ):
+                    raise Win32Error("GetDIBits failed")
+                raw_bytes = bytes(buffer)
+                if Image is None:
+                    return raw_bytes
+                image = Image.frombuffer("RGBA", (width, height), raw_bytes, "raw", "BGRA", 0, 1)
+                with io.BytesIO() as stream:
+                    image.save(stream, format="PNG")
+                    return stream.getvalue()
+            finally:
+                self.gdi32.DeleteObject(bitmap)
+                self.gdi32.DeleteDC(hdc_mem)
+                self.user32.ReleaseDC(0, hdc_screen)
+
+        def send_key(self, vk_code: int) -> None:
+            inputs = (INPUT * 2)()
+            inputs[0].type = INPUT_KEYBOARD
+            inputs[0].union.ki = KEYBDINPUT(wVk=vk_code, wScan=0, dwFlags=0, time=0, dwExtraInfo=0)
+            inputs[1].type = INPUT_KEYBOARD
+            inputs[1].union.ki = KEYBDINPUT(wVk=vk_code, wScan=0, dwFlags=KEYEVENTF_KEYUP, time=0, dwExtraInfo=0)
+            sent = self.user32.SendInput(2, ctypes.byref(inputs), ctypes.sizeof(INPUT))
+            if sent != 2:
+                raise Win32Error("SendInput failed")
+
+else:  # pragma: no cover - placeholder for non-Windows environments
+
+    class RealWin32API:  # type: ignore[override]
+        def __init__(self) -> None:
+            raise RuntimeError("RealWin32API is only available on Windows")
+
+        def list_monitors(self) -> Sequence[Rect]:
+            raise RuntimeError("RealWin32API is only available on Windows")
+
+        def get_foreground_window_rect(self) -> Rect | None:
+            raise RuntimeError("RealWin32API is only available on Windows")
+
+        def capture_rect(self, rect: Rect) -> bytes:
+            raise RuntimeError("RealWin32API is only available on Windows")
+
+        def send_key(self, vk_code: int) -> None:
+            raise RuntimeError("RealWin32API is only available on Windows")

--- a/src/scu/tools/__init__.py
+++ b/src/scu/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Build and packaging helpers for SCU."""

--- a/src/scu/tools/build_exe.py
+++ b/src/scu/tools/build_exe.py
@@ -1,0 +1,79 @@
+"""Utilities for creating a distributable Windows executable."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+
+def build_executable(
+    dist_path: Path | None = None,
+    *,
+    onefile: bool = True,
+    clean: bool = True,
+    name: str = "scu-gui",
+) -> None:
+    """Invoke PyInstaller to bundle the GUI into an executable."""
+
+    try:
+        import PyInstaller.__main__ as pyinstaller_main
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised in tests via stubs
+        raise RuntimeError(
+            "PyInstaller is required to build the executable. Install the 'build' extra first."
+        ) from exc
+
+    entry_point = Path(__file__).resolve().parents[1] / "gui" / "main.py"
+
+    args = ["--noconfirm", "--windowed", f"--name={name}"]
+    if clean:
+        args.append("--clean")
+    if onefile:
+        args.append("--onefile")
+    if dist_path is not None:
+        args.append(f"--distpath={Path(dist_path).resolve()}")
+    args.append(str(entry_point))
+
+    pyinstaller_main.run(args)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Command line interface for :func:`build_executable`."""
+
+    parser = argparse.ArgumentParser(description="Bundle the SCU GUI into a Windows executable.")
+    parser.add_argument(
+        "--dist",
+        type=Path,
+        default=None,
+        help="Directory where the executable should be written (defaults to PyInstaller's dist path)",
+    )
+    parser.add_argument(
+        "--name",
+        default="scu-gui",
+        help="Name of the generated executable.",
+    )
+    parser.add_argument(
+        "--onedir",
+        action="store_true",
+        help="Create a folder-based distribution instead of a single file.",
+    )
+    parser.add_argument(
+        "--no-clean",
+        action="store_true",
+        help="Skip PyInstaller's clean step to speed up repeated builds.",
+    )
+
+    args = parser.parse_args(argv)
+    build_executable(
+        dist_path=args.dist,
+        onefile=not args.onedir,
+        clean=not args.no_clean,
+        name=args.name,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI convenience
+    main()
+
+
+__all__ = ["build_executable", "main"]

--- a/tests/test_build_exe.py
+++ b/tests/test_build_exe.py
@@ -1,0 +1,48 @@
+from types import ModuleType
+from pathlib import Path
+import sys
+
+from scu.tools import build_exe
+
+
+def test_build_executable_constructs_expected_arguments(monkeypatch, tmp_path: Path) -> None:
+    recorded: dict[str, list[str]] = {}
+
+    stub_parent = ModuleType("PyInstaller")
+    stub_main = ModuleType("PyInstaller.__main__")
+
+    def fake_run(args: list[str]) -> None:
+        recorded["args"] = list(args)
+
+    stub_main.run = fake_run  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "PyInstaller", stub_parent)
+    monkeypatch.setitem(sys.modules, "PyInstaller.__main__", stub_main)
+
+    build_exe.build_executable(dist_path=tmp_path, onefile=False, clean=False, name="custom")
+
+    args = recorded["args"]
+    assert "--onefile" not in args
+    assert "--clean" not in args
+    assert "--windowed" in args
+    assert "--noconfirm" in args
+    assert "--name=custom" in args
+    assert f"--distpath={tmp_path.resolve()}" in args
+    assert args[-1].endswith("scu/gui/main.py")
+
+
+def test_main_parses_cli_arguments(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_builder(**kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setitem(sys.modules, "PyInstaller", ModuleType("PyInstaller"))
+    monkeypatch.setitem(sys.modules, "PyInstaller.__main__", ModuleType("PyInstaller.__main__"))
+    monkeypatch.setattr(build_exe, "build_executable", lambda **kwargs: fake_builder(**kwargs))
+
+    build_exe.main(["--dist", str(tmp_path), "--onedir", "--no-clean", "--name", "demo"])
+
+    assert captured["dist_path"] == tmp_path
+    assert captured["onefile"] is False
+    assert captured["clean"] is False
+    assert captured["name"] == "demo"

--- a/tests/test_output_writer.py
+++ b/tests/test_output_writer.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from scu.config import ImageFormat
+from scu.output import FilesystemOutputWriter
+
+
+def test_filesystem_output_writer_persists_bytes(tmp_path: Path) -> None:
+    writer = FilesystemOutputWriter()
+    session_dir = tmp_path / "session"
+
+    result = writer.write_capture(
+        session_dir=session_dir,
+        index=1,
+        image_format=ImageFormat.PNG,
+        image_bytes=b"payload",
+        jpeg_quality=90,
+    )
+
+    assert result == session_dir / "page_0001.png"
+    assert result.read_bytes() == b"payload"

--- a/tests/test_windows_platform.py
+++ b/tests/test_windows_platform.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import hashlib
+import sys
+
+import pytest
+
+from scu.config import CaptureMode, Direction
+from scu.interfaces import CaptureRequest
+from scu.platform.windows import Rect, Win32CaptureService, Win32InputService, Win32WaitService
+
+
+class FakeWin32API:
+    def __init__(self) -> None:
+        self.monitors = [Rect(0, 0, 1920, 1080)]
+        self.foreground: Rect | None = Rect(100, 100, 400, 300)
+        self.captured_rects: list[Rect] = []
+        self.sent_keys: list[int] = []
+
+    def list_monitors(self) -> list[Rect]:
+        return self.monitors
+
+    def get_foreground_window_rect(self) -> Rect | None:
+        return self.foreground
+
+    def capture_rect(self, rect: Rect) -> bytes:
+        self.captured_rects.append(rect)
+        return f"capture:{rect.left},{rect.top},{rect.right},{rect.bottom}".encode()
+
+    def send_key(self, vk_code: int) -> None:
+        self.sent_keys.append(vk_code)
+
+
+class FakeTimer:
+    def __init__(self) -> None:
+        self.current = 0.0
+        self.slept: list[float] = []
+
+    def sleep(self, delay: float) -> None:
+        self.slept.append(delay)
+        self.current += max(0.0, delay)
+
+    def monotonic(self) -> float:
+        return self.current
+
+
+def test_capture_full_monitor_uses_monitor_bounds() -> None:
+    api = FakeWin32API()
+    service = Win32CaptureService(api=api)
+    request = CaptureRequest(monitor=1, capture_mode=CaptureMode.FULL_MONITOR, min_overlap=0.5)
+
+    result = service.capture(request)
+
+    assert result.width == 1920
+    assert result.height == 1080
+    assert api.captured_rects[-1] == api.monitors[0]
+    assert result.hash_value == hashlib.sha1(b"capture:0,0,1920,1080").hexdigest()
+
+
+def test_services_require_windows_when_no_api() -> None:
+    if sys.platform == "win32":
+        pytest.skip("platform check only relevant for non-Windows CI")
+
+    with pytest.raises(RuntimeError):
+        Win32CaptureService()
+
+    with pytest.raises(RuntimeError):
+        Win32InputService()
+
+
+def test_capture_active_window_clamps_to_monitor() -> None:
+    api = FakeWin32API()
+    api.foreground = Rect(-50, 10, 150, 110)  # partially outside the monitor
+    service = Win32CaptureService(api=api)
+    request = CaptureRequest(monitor=1, capture_mode=CaptureMode.ACTIVE_WINDOW, min_overlap=0.1)
+
+    result = service.capture(request)
+
+    assert api.captured_rects[-1] == Rect(0, 10, 150, 110)
+    assert result.width == 150
+    assert result.height == 100
+
+
+def test_capture_active_window_overlap_validation() -> None:
+    api = FakeWin32API()
+    api.foreground = Rect(1910, 0, 2100, 200)
+    service = Win32CaptureService(api=api)
+    request = CaptureRequest(monitor=1, capture_mode=CaptureMode.ACTIVE_WINDOW, min_overlap=0.8)
+
+    with pytest.raises(RuntimeError):
+        service.capture(request)
+
+
+def test_capture_invalid_monitor_raises() -> None:
+    api = FakeWin32API()
+    service = Win32CaptureService(api=api)
+    request = CaptureRequest(monitor=2, capture_mode=CaptureMode.FULL_MONITOR, min_overlap=0.5)
+
+    with pytest.raises(ValueError):
+        service.capture(request)
+
+
+def test_input_service_sends_correct_key() -> None:
+    api = FakeWin32API()
+    input_service = Win32InputService(api=api)
+
+    input_service.send_direction(Direction.LEFT)
+    input_service.send_direction(Direction.RIGHT)
+
+    assert api.sent_keys == [Win32InputService.VK_LEFT, Win32InputService.VK_RIGHT]
+
+
+def test_wait_service_detects_change_before_timeout() -> None:
+    timer = FakeTimer()
+    hashes = iter(["abc", "abc", "def"])
+    service = Win32WaitService(
+        change_detector=lambda: next(hashes, "def"),
+        poll_interval=0.2,
+        sleep_fn=timer.sleep,
+        monotonic_fn=timer.monotonic,
+    )
+
+    assert service.wait_for_change("abc", 1.0) is True
+    # slept at least twice (one poll + exit)
+    assert timer.current >= 0.2
+
+
+def test_wait_service_times_out_when_no_change() -> None:
+    timer = FakeTimer()
+    service = Win32WaitService(
+        change_detector=lambda: "same",
+        poll_interval=0.2,
+        sleep_fn=timer.sleep,
+        monotonic_fn=timer.monotonic,
+    )
+
+    assert service.wait_for_change("same", 0.5) is False
+    assert timer.current == pytest.approx(0.5, rel=1e-6)
+
+
+def test_wait_fixed_uses_sleep() -> None:
+    timer = FakeTimer()
+    service = Win32WaitService(sleep_fn=timer.sleep, monotonic_fn=timer.monotonic)
+
+    service.wait_fixed(0.3)
+
+    assert timer.current == pytest.approx(0.3, rel=1e-6)


### PR DESCRIPTION
## Summary
- add a PySide6-powered GUI that wires the existing session pipeline into a Windows desktop app with start/pause/resume controls
- introduce a filesystem output writer, packaging CLI, and documentation updates for running the GUI and building a standalone exe
- cover the new utilities with tests and update pipeline tests to reuse the shared writer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e51d1991188332841a092d4c0882dd